### PR TITLE
Add script to download YouTube video transcript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nb/*
+.DS_Store

--- a/bin/get-transcript.sh
+++ b/bin/get-transcript.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Downloads audio and transcript of a YouTube video to the current directory.
+# Requires `youtube-dl` and `ffmpeg`.
+
+TRANSCRIPT_BASE="https://www.youtube.com/api/timedtext?lang=en&v="
+
+if [ -z "$1" ]; then
+  echo "Usage: ./get-transcript.sh <VIDEO_ID>"
+  exit 2
+fi
+
+# Attempt to download XML transcript
+if curl --silent --fail --output "$1.xml" "${TRANSCRIPT_BASE}${1}"; then
+  echo "Downloaded transcript to $1.xml."
+else
+  echo "Unable to download transcript."
+  exit 1
+fi
+
+youtube-dl --all-subs --extract-audio --audio-format="wav" --output="$1/$1.%(ext)s" "$1"

--- a/collector/get-transcript.sh
+++ b/collector/get-transcript.sh
@@ -10,9 +10,12 @@ if [ -z "$1" ]; then
   exit 2
 fi
 
+# Make new directory for downloaded files
+mkdir -p "$1"
+
 # Attempt to download XML transcript
-if curl --silent --fail --output "$1.xml" "${TRANSCRIPT_BASE}${1}"; then
-  echo "Downloaded transcript to $1.xml."
+if curl --silent --fail --output "$1/$1.xml" "${TRANSCRIPT_BASE}${1}"; then
+  echo "Downloaded transcript to $1/$1.xml."
 else
   echo "Unable to download transcript."
   exit 1


### PR DESCRIPTION
:hourglass: **Status**: _Ready for Review_
:tickets: **Ticket(s)**: #33

## :construction_worker: Changes
- Add `collector/get-transcript.sh`
- Add `.DS_Store` to `.gitignore`.

## :flashlight: Testing Instructions
- `brew install youtube-dl ffmpeg`
- Try calling `./get-transcript.sh <video-id>` on valid and invalid video IDs.
  - A new subdirectory with the name of the video ID gets created in the current directory, and the audio and transcript files get saved there.