### PR TITLE
Add stub for audio upload endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request, jsonify
 
 
 app = Flask(__name__)
@@ -7,6 +7,27 @@ app = Flask(__name__)
 @app.route("/")
 def hello():
     return "Hello, world!"
+
+
+@app.route("/upload", methods=['POST'])
+def upload_audio():
+    """
+    Accepts a file as part of a POST request.
+    """
+
+    if 'file' not in request.files:
+        return "No file given in request.", 400
+
+    # TODO: Process the received audio data!
+    f = request.files['file']
+    data = f.read()
+
+    return jsonify({
+        'mimetype': f.mimetype,
+        'filename': f.filename,
+        'leading_bytes': str(data)[:64],
+        'size': len(data),
+    })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## :construction_worker: Changes

Adds a simple POST endpoint at `/upload` that can accept file uploads. For now, the endpoint just returns some basic information about the uploaded file (ie. name, type, size, and the leading bytes of the file). Closes #46.

## :flashlight: Testing Instructions

Build the server and upload a file via a POST request.

```bash
$ make build-prod && make run

# Using cURL:
$ curl -i -X POST -F "file=@${PATH_TO_FILE}" http://localhost:80/upload

# Using HTTPie:
$ http -f POST :80/upload file@${PATH_TO_FILE}
```

The server should respond with some information like this:

```json
{
  "filename": "nature24270.pdf",
  "leading_bytes": "b'%PDF-1.3\\n%\\xc4\\xe5\\xf2\\xe5\\xeb\\xa7\\xf3\\xa0\\xd0\\xc4\\xc6\\n6 0 o",
  "mimetype": "application/octet-stream",
  "size": 7752280
}
```

----

:hourglass: **Status**: Open for Visibility
:tickets: **Ticket(s)**: #46