### PR TITLE
Updated to output only a single column

### DIFF
--- a/app/collector/extract_labels.py
+++ b/app/collector/extract_labels.py
@@ -84,7 +84,7 @@ def extract_labels(xml, left_delim, right_delim,
     logger.info('Speakers found: {}'.format(speaker_dict))
 
     # Produce result matrix.
-    labels = np.zeros((num_obs, len(speakers)), dtype=np.int32)
+    labels = np.zeros((num_obs, 1), dtype=np.int32)
 
     # Reference to the current speaker
     current = None
@@ -103,15 +103,15 @@ def extract_labels(xml, left_delim, right_delim,
 
         # If discard, leave -1's so we can remove rows later.
         if not valid_text(text, re_delim, re_discard):
-            labels[start_obs:end_obs, :] = -1
+            labels[start_obs:end_obs, 1] = -1 # bad data
         elif current:
-            labels[start_obs:end_obs, speaker_dict[current]] = 1
+            labels[start_obs:end_obs, 1] = speaker_dict[current] + 1  #1 to n
 
         logger.debug(text)
         logger.debug('Result: {}'.format(labels[start_obs]))
 
     logger.info('Result shape: {}'.format(labels.shape))
-    logger.info('Expected shape: ({},{})'.format(num_obs, len(speakers)))
+    logger.info('Expected shape: ({},{})'.format(num_obs, 1))
     logger.info('Time spent: {}'.format(time.time() - start_profile))
 
     return labels

--- a/app/collector/extract_labels.py
+++ b/app/collector/extract_labels.py
@@ -103,9 +103,9 @@ def extract_labels(xml, left_delim, right_delim,
 
         # If discard, leave -1's so we can remove rows later.
         if not valid_text(text, re_delim, re_discard):
-            labels[start_obs:end_obs, 1] = -1 # bad data
+            labels[start_obs:end_obs] = -1 # bad data
         elif current:
-            labels[start_obs:end_obs, 1] = speaker_dict[current] + 1  #1 to n
+            labels[start_obs:end_obs] = speaker_dict[current] + 1  #1 to n
 
         logger.debug(text)
         logger.debug('Result: {}'.format(labels[start_obs]))


### PR DESCRIPTION
## :construction_worker: Changes

updated ```extract_labels.py``` to have 1 column for output.

```1 to n``` represents speakers, ```0``` represents no speaker, ```-1``` represents bad data.

## :flashlight: Testing Instructions

```python3 pipeline.py```
then verify output of ```extract_labels.py``` is one in second dimension.

----

:hourglass: **Status**: Ready for Review
:tickets: **Ticket(s)**: #65
