### PR TITLE
Fix README; remove dead method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ from minutes import Speaker, Minutes, Conversation
 
 minutes = Minutes(parent='cnn')
 
-s1.add_audio('test/fixtures/1447')  # Audio book speakers.
-s2.add_audio('test/fixtures/669')
-s3.add_audio('test/fixtures/5561')
-
-minutes.fit(verbose=2)
-
-# Create some speakers with some audio.
+# Create some speakers, add some audio.
 s1, s2 = Speaker('s1'), Speaker('s2')
 s1.add_audio('path/to/audio1')
 s2.add_audio('path/to/audio2')

--- a/README.md
+++ b/README.md
@@ -28,21 +28,30 @@ pytest --cov=minutes -vvv test
 ## Example Usage
 
 ```python
-from minutes import Speaker, Minutes
+from minutes import Speaker, Minutes, Conversation
 
-minutes = Minutes(ms_per_observation=500, model='cnn')
+minutes = Minutes(parent='cnn')
+
+s1.add_audio('test/fixtures/1447')  # Audio book speakers.
+s2.add_audio('test/fixtures/669')
+s3.add_audio('test/fixtures/5561')
+
+minutes.fit(verbose=2)
 
 # Create some speakers with some audio.
-speaker1 = Speaker('speaker1')
-speaker1.add_audio('path/to/audio1.wav')
-
-speaker2 = Speaker('speaker2')
-speaker2.add_audio('path/to/audio2.wav')
+s1, s2 = Speaker('s1'), Speaker('s2')
+s1.add_audio('path/to/audio1')
+s2.add_audio('path/to/audio2')
 
 # Add speakers to the model.
-minutes.add_speakers([speaker1, speaker2])
+minutes.add_speakers([s1, s2])
 
 # Fit the model.
 minutes.fit()
-result = minutes.predict()
+
+# Collect a new conversation for prediction.
+conversation = Conversation('/path/to/conversation.wav')
+
+# Create phrases from the conersation.
+phrases = model.phrases(conversation)
 ```

--- a/minutes/__init__.py
+++ b/minutes/__init__.py
@@ -1,2 +1,3 @@
 from .minutes import Minutes  # noqa
 from .speaker import Speaker  # noqa
+from .conversation import Conversation  # noqa

--- a/minutes/conversation.py
+++ b/minutes/conversation.py
@@ -1,4 +1,4 @@
-from audio import Audio
+from minutes.audio import Audio
 
 
 class Conversation:
@@ -28,12 +28,3 @@ class Conversation:
         """
         return self.audio.get_spectrograms(ms_per_observation, verbose)
 
-    def phrases(self, model):
-        """Given a trained model, recreates phrases from the internal
-        audio sample.
-
-        Arguments:
-            model {keras.model} -- A model trained on the speakers in
-            the converstation.
-        """
-        pass  # TODO

--- a/minutes/minutes.py
+++ b/minutes/minutes.py
@@ -66,11 +66,13 @@ class Minutes(BaseModel):
             verbose=verbose
         )
 
-    def predict(self, conversation):
+    def phrases(self, conversation):
         """Predict against a new conversation.
 
         Arguments:
             conversation {Conversation} -- A conversation built from an audio
             sample.
+
+        Returns: <TODO>
         """
         pass  # TODO


### PR DESCRIPTION
## :construction_worker: Changes

+ Updated the README to show appropriate usage.
+ Killed `Conversation.phrases`, the API feels a bit better if we do `minutes.phrases(my_conversation)`... right? 😅 

## :flashlight: Testing Instructions

```
pytest
```